### PR TITLE
Fix: Remove space before colon in return type declaration

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -38,7 +38,7 @@ class provider implements \core_privacy\local\metadata\null_provider {
      *
      * @return string
      */
-    public static function get_reason() : string {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }


### PR DESCRIPTION
This pull request fixes a code style issue by removing unnecessary spaces before colons in return type declarations across the codebase, as implemented in the next commit:

-Fix: Remove space before colon in return type declaration.

