### PR TITLE
Fix: Return Type Spacing and Docblock issues

### DIFF
--- a/classes/asset_manager.php
+++ b/classes/asset_manager.php
@@ -51,7 +51,9 @@ class asset_manager {
     }
 
     /**
-     * @return array
+     * Retrieves a list of assets.
+     *
+     * @return array List of asset objects with name, href, and type.
      */
     public function get_assets() {
         $assets = [];

--- a/classes/form/assets_form.php
+++ b/classes/form/assets_form.php
@@ -39,7 +39,9 @@ require_once(__DIR__ . '/../../../../../lib/formslib.php');
 class assets_form extends \moodleform {
 
     /**
-     * @return array
+     * Retrieves options for the file manager element.
+     *
+     * @return array Array of options for the file manager, including accepted types and subdir settings.
      */
     public static function get_options() {
         global $CFG;
@@ -65,7 +67,9 @@ class assets_form extends \moodleform {
             'subdirs' => true,
         ];
     }
-
+    /**
+     * Defines the form elements.
+     */
     public function definition() {
         $mform = $this->_form;
 

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -38,7 +38,7 @@ class provider implements \core_privacy\local\metadata\null_provider {
      *
      * @return string
      */
-    public static function get_reason() : string {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -23,6 +23,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+/**
+ * Handles serving of files for the Theme assets tool.
+ *
+ * @param stdClass $course The course object.
+ * @param stdClass $cm Course module.
+ * @param context $context Context object.
+ * @param string $filearea The file area.
+ * @param array $args Additional arguments.
+ * @param bool $forcedownload Whether or not force download.
+ * @param array $options Additional options affecting file serving.
+ * @return bool False if the file not found or context is incorrect.
+ */
 function tool_themeassets_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload, $options = []) {
     if (!$context instanceof \context_system) {
         return false;

--- a/tests/options_test.php
+++ b/tests/options_test.php
@@ -34,6 +34,8 @@ use tool_themeassets\form\assets_form;
 class options_test extends \advanced_testcase {
     /**
      * Test that overriding accepted types omits wildcard file type usage.
+     *
+     * @covers ::test_options_omit_asterisk
      */
     public function test_options_omit_asterisk() {
         global $CFG;


### PR DESCRIPTION
This pull request enhances code quality and maintainability by adding missing docblocks, fixing PHPdoc formatting, and removing unnecessary spaces before colons in return type declarations across the codebase. 
Fixes errors:
-No one-line description found in phpdocs for docblock of function. 
-Missing docblock for function definition.
-There must not be a space before the colon in a return type declaration.